### PR TITLE
Improve network test to support older and newer network tools

### DIFF
--- a/src/linux/macgonuts_native_gw_utils.c
+++ b/src/linux/macgonuts_native_gw_utils.c
@@ -44,10 +44,6 @@ int get_gw_addr6_info(uint8_t *raw, size_t *raw_size, const char *iface) {
         bp--;
     }
 
-    if (bp == &buf[0]) {
-        return EXIT_FAILURE;
-    }
-
     rp = raw;
     rp_end = rp + 16;
     while (rp != rp_end) {

--- a/src/test/macgonuts_metaspoofer_tests.c
+++ b/src/test/macgonuts_metaspoofer_tests.c
@@ -47,9 +47,9 @@ CUTE_TEST_CASE(macgonuts_metaspoofer_tests)
     spfgd.layers.proto_addr_size = 4;
     spfgd.metainfo.arg[0] = &hooks;
     memcpy(&spfgd.layers.lo_hw_addr[0], "\xAA\xBB\xCC\xDD\xEE\xFF", sizeof(spfgd.layers.lo_hw_addr));
-    memcpy(&spfgd.layers.lo_proto_addr[0], "\x7F\x00\x00\x01", sizeof(spfgd.layers.lo_proto_addr));
-    memcpy(&spfgd.layers.tg_proto_addr[0], "\x7F\x00\x00\x02", sizeof(spfgd.layers.tg_proto_addr));
-    memcpy(&spfgd.layers.spoof_proto_addr[0], "\x7F\x00\x00\x03", sizeof(spfgd.layers.spoof_proto_addr));
+    memcpy(&spfgd.layers.lo_proto_addr[0], "\x7F\x00\x00\x01", 4);
+    memcpy(&spfgd.layers.tg_proto_addr[0], "\x7F\x00\x00\x02", 4);
+    memcpy(&spfgd.layers.spoof_proto_addr[0], "\x7F\x00\x00\x03", 4);
     memcpy(&spfgd.layers.tg_hw_addr[0], "\x00\x01\x02\x03\x04\x05", sizeof(spfgd.layers.tg_hw_addr));
     memcpy(&spfgd.layers.spoof_hw_addr[0], "\xAA\x01\xBB\x04\xCC\x05", sizeof(spfgd.layers.spoof_hw_addr));
     CUTE_ASSERT(macgonuts_create_thread(&td, gohome, &spfgd) == EXIT_SUCCESS);

--- a/src/test/macgonuts_socket_common_tests.c
+++ b/src/test/macgonuts_socket_common_tests.c
@@ -56,19 +56,31 @@ CUTE_TEST_CASE(macgonuts_get_maxaddr_from_iface_tests)
     CUTE_ASSERT(get_maxaddr4_from_iface(expected, iface) == EXIT_SUCCESS);
     CUTE_ASSERT(memcmp(&netmask[0], &expected[0], 4) == 0);
 #if defined(__linux__)
-    snprintf(cmd, sizeof(cmd) - 1, "ifconfig %s inet6 del dead:beef:0:cafe:fed1::d0/64 >/dev/null 2>&1", iface);
+    if (has_ifconfig()) {
+        snprintf(cmd, sizeof(cmd) - 1, "ifconfig %s inet6 del dead:beef:0:cafe:fed1::d0/64 >/dev/null 2>&1", iface);
+    } else {
+        snprintf(cmd, sizeof(cmd) - 1, "ip -6 addr del dev %s dead:beef:0:cafe:fed1::d0/64 >/dev/null 2>&1", iface);
+    }
 #elif defined(__FreeBSD__)
     snprintf(cmd, sizeof(cmd) - 1, "ifconfig %s inet6 dead:beef:0:cafe:fed1::d0/64 -alias >/dev/null 2>&1", iface);
 #else
 # error Some code wanted.
 #endif // defined(__linux__)
     system(cmd);
-    snprintf(cmd, sizeof(cmd) - 1, "ifconfig %s inet6 add dead:beef:0:cafe:fed1::d0/64", iface);
+    if (has_ifconfig()) {
+        snprintf(cmd, sizeof(cmd) - 1, "ifconfig %s inet6 add dead:beef:0:cafe:fed1::d0/64", iface);
+    } else {
+        snprintf(cmd, sizeof(cmd) - 1, "ip -6 addr add dev %s dead:beef:0:cafe:fed1::d0/64", iface);
+    }
     CUTE_ASSERT(system(cmd) == 0);
     CUTE_ASSERT(get_maxaddr6_from_iface(expected, iface) == EXIT_SUCCESS);
     CUTE_ASSERT(macgonuts_get_maxaddr_from_iface(iface, iface_size, netmask, 6) == EXIT_SUCCESS);
 #if defined(__linux__)
-    snprintf(cmd, sizeof(cmd) - 1, "ifconfig %s inet6 del dead:beef:0:cafe:fed1::d0/64", iface);
+    if (has_ifconfig()) {
+        snprintf(cmd, sizeof(cmd) - 1, "ifconfig %s inet6 del dead:beef:0:cafe:fed1::d0/64", iface);
+    } else {
+        snprintf(cmd, sizeof(cmd) - 1, "ip -6 addr del dev %s dead:beef:0:cafe:fed1::d0/64", iface);
+    }
 #elif defined(__FreeBSD__)
     snprintf(cmd, sizeof(cmd) - 1, "ifconfig %s inet6 dead:beef:0:cafe:fed1::d0/64 -alias", iface);
 #else
@@ -85,14 +97,22 @@ CUTE_TEST_CASE(macgonuts_get_netmask_from_iface_tests)
     const char *iface = get_default_iface_name();
     const size_t iface_size = strlen(iface);
 #if defined(__linux__)
-    snprintf(cmd, sizeof(cmd) - 1, "ifconfig %s inet6 del dead:beef:0:cafe:fed1::d0/64 >/dev/null 2>&1", iface);
+    if (has_ifconfig()) {
+        snprintf(cmd, sizeof(cmd) - 1, "ifconfig %s inet6 del dead:beef:0:cafe:fed1::d0/64 >/dev/null 2>&1", iface);
+    } else {
+        snprintf(cmd, sizeof(cmd) - 1, "ip -6 addr del dev %s dead:beef:0:cafe:fed1::d0/64 >/dev/null 2>&1", iface);
+    }
 #elif defined(__FreeBSD__)
     snprintf(cmd, sizeof(cmd) - 1, "ifconfig %s inet6 dead:beef:0:cafe:fed1::d0/64 -alias >/dev/null 2>&1", iface);
 #else
 # error Some code wanted.
 #endif // defined(__linux__)
     system(cmd);
-    snprintf(cmd, sizeof(cmd) - 1, "ifconfig %s inet6 add dead:beef:0:cafe:fed1::d0/64", iface);
+    if (has_ifconfig()) {
+        snprintf(cmd, sizeof(cmd) - 1, "ifconfig %s inet6 add dead:beef:0:cafe:fed1::d0/64", iface);
+    } else {
+        snprintf(cmd, sizeof(cmd) - 1, "ip -6 addr add dev %s dead:beef:0:cafe:fed1::d0/64", iface);
+    }
     CUTE_ASSERT(system(cmd) == 0);
     CUTE_ASSERT(macgonuts_get_netmask_from_iface(NULL, iface_size, netmask, 4) == EINVAL);
     CUTE_ASSERT(macgonuts_get_netmask_from_iface(iface, 0, netmask, 4) == EINVAL);
@@ -105,7 +125,11 @@ CUTE_TEST_CASE(macgonuts_get_netmask_from_iface_tests)
     CUTE_ASSERT(macgonuts_get_netmask_from_iface(iface, iface_size, netmask, 6) == EXIT_SUCCESS);
     CUTE_ASSERT(memcmp(&netmask[0], &expected[0], 16) == 0);
 #if defined(__linux__)
-    snprintf(cmd, sizeof(cmd) - 1, "ifconfig %s inet6 del dead:beef:0:cafe:fed1::d0/64", iface);
+    if (has_ifconfig()) {
+        snprintf(cmd, sizeof(cmd) - 1, "ifconfig %s inet6 del dead:beef:0:cafe:fed1::d0/64", iface);
+    } else {
+        snprintf(cmd, sizeof(cmd) - 1, "ip -6 addr del dev %s dead:beef:0:cafe:fed1::d0/64", iface);
+    }
 #elif defined(__FreeBSD__)
     snprintf(cmd, sizeof(cmd) - 1, "ifconfig %s inet6 dead:beef:0:cafe:fed1::d0/64 -alias", iface);
 #else
@@ -129,21 +153,33 @@ CUTE_TEST_CASE(macgonuts_get_gateway_addr_info_from_iface_tests)
     CUTE_ASSERT(addr_size == 4);
     CUTE_ASSERT(memcmp(&addr[0], &expected_addr, addr_size) == 0);
 #if defined(__linux__)
-    snprintf(cmd, sizeof(cmd) - 1, "ifconfig %s inet6 del dead:beef:0:cafe:fed1::d0/64 >/dev/null 2>&1", iface);
+    if (has_ifconfig()) {
+        snprintf(cmd, sizeof(cmd) - 1, "ifconfig %s inet6 del dead:beef:0:cafe:fed1::d0/64 >/dev/null 2>&1", iface);
+    } else {
+        snprintf(cmd, sizeof(cmd) - 1, "ip -6 addr del dev %s dead:beef:0:cafe:fed1::d0/64 > /dev/null 2>&1", iface);
+    }
 #elif defined(__FreeBSD__)
     snprintf(cmd, sizeof(cmd) - 1, "ifconfig %s inet6 dead:beef:0:cafe:fed1::d0/64 -alias >/dev/null 2>&1", iface);
 #else
 # error Some code wanted.
 #endif // defined(__linux__)
     system(cmd);
-    snprintf(cmd, sizeof(cmd) - 1, "ifconfig %s inet6 add dead:beef:0:cafe:fed1::d0/64", iface);
+    if (has_ifconfig()) {
+        snprintf(cmd, sizeof(cmd) - 1, "ifconfig %s inet6 add dead:beef:0:cafe:fed1::d0/64", iface);
+    } else {
+        snprintf(cmd, sizeof(cmd) - 1, "ip -6 addr add dev %s dead:beef:0:cafe:fed1::d0/64", iface);
+    }
     CUTE_ASSERT(system(cmd) == 0);
     get_gateway_addr6_from_iface(expected_addr, iface);
     CUTE_ASSERT(macgonuts_get_gateway_addr_info_from_iface(&addr[0], &addr_size, 6, iface) == EXIT_SUCCESS);
     CUTE_ASSERT(addr_size == 16);
     CUTE_ASSERT(memcmp(&addr[0], &expected_addr[0], addr_size) == 0);
 #if defined(__linux__)
-    snprintf(cmd, sizeof(cmd) - 1, "ifconfig %s inet6 del dead:beef:0:cafe:fed1::d0/64", iface);
+    if (has_ifconfig()) {
+        snprintf(cmd, sizeof(cmd) - 1, "ifconfig %s inet6 del dead:beef:0:cafe:fed1::d0/64", iface);
+    } else {
+        snprintf(cmd, sizeof(cmd) - 1, "ip -6 addr del dev %s dead:beef:0:cafe:fed1::d0/64 > /dev/null 2>&1", iface);
+    }
 #elif defined(__FreeBSD__)
     snprintf(cmd, sizeof(cmd) - 1, "ifconfig %s inet6 dead:beef:0:cafe:fed1::d0/64 -alias", iface);
 #else

--- a/src/test/macgonuts_spoof_tests.c
+++ b/src/test/macgonuts_spoof_tests.c
@@ -90,9 +90,9 @@ CUTE_TEST_CASE(macgonuts_spoof_tests)
     spf_layers.proto_addr_size = 4;
     spf_layers.always_do_pktcraft = 1;
     memcpy(&spf_layers.lo_hw_addr[0], "\xAA\xBB\xCC\xDD\xEE\xFF", sizeof(spf_layers.lo_hw_addr));
-    memcpy(&spf_layers.lo_proto_addr[0], "\x7F\x00\x00\x01", sizeof(spf_layers.lo_proto_addr));
-    memcpy(&spf_layers.tg_proto_addr[0], "\x7F\x00\x00\x02", sizeof(spf_layers.tg_proto_addr));
-    memcpy(&spf_layers.spoof_proto_addr[0], "\x7F\x00\x00\x03", sizeof(spf_layers.spoof_proto_addr));
+    memcpy(&spf_layers.lo_proto_addr[0], "\x7F\x00\x00\x01", 4);
+    memcpy(&spf_layers.tg_proto_addr[0], "\x7F\x00\x00\x02", 4);
+    memcpy(&spf_layers.spoof_proto_addr[0], "\x7F\x00\x00\x03", 4);
     memcpy(&spf_layers.tg_hw_addr[0], "\x00\x01\x02\x03\x04\x05", sizeof(spf_layers.tg_hw_addr));
     memcpy(&spf_layers.spoof_hw_addr[0], "\xAA\x01\xBB\x04\xCC\x05", sizeof(spf_layers.spoof_hw_addr));
     CUTE_ASSERT(macgonuts_spoof(rsk, &spf_layers) == EXIT_SUCCESS);

--- a/src/test/macgonuts_test_utils.h
+++ b/src/test/macgonuts_test_utils.h
@@ -32,4 +32,6 @@ void get_gateway_addr4_from_iface(uint8_t *gw_addr, const char *iface);
 
 void get_gateway_addr6_from_iface(uint8_t *gw_addr, const char *iface);
 
+int has_ifconfig(void);
+
 #endif // MACGONUTS_TEST_MACGONUTS_TEST_UTILS_H


### PR DESCRIPTION
This commit adds support for ip command when running in Linux environment that does not support deprecated ifconfig tool.

This improvement makes possible execute unit tests from newer or older distros.