### PR TITLE
Rename macgonuts_gethostsbyname() to macgonuts_gethoaxbyname()

### DIFF
--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -814,15 +814,15 @@ Well, now you master anything about silence, congrats!
 
 ><img src="https://github.com/rafael-santiago/macgonuts/blob/main/etc/angry-hiss.gif" title="Grrrr! C4uTion is now logged in..."
      alt="Grrrr! C4uTion is now logged in..." width="70" />
- If you want to deny `SLAAC` based `link-local` address atribution in an `IPv6` network or being more straightforward if you
+ If you want to deny `SLAAC` based `link-local` address attribution in an `IPv6` network or being more straightforward if you
 want to promote a `DoS` attack by exploiting `DAD`. "Let's go baby, let's go bad, you should give a try to ma-ma-ma-maddady" :stuck_out_tongue_winking_eye:
 
-The `maddaddy` is a pretty straightforward command. All it expects is the interface that you use to access the `IPv6` available
-in your network environment.
+The `maddaddy` is a pretty straightforward command. All it expects is the interface that you use to access `IPv6`
+stuff in your network environment.
 
 Yeah, ridiculous but: story time!!!!
 
-Once upon time `GooGoo`. He hated network addresses in hexadecimal format and made up his mind about deny any device in his
+Once upon time `GooGoo`. He hated network addresses in hexadecimal format and made up his mind about denying any device in his
 network of using this bad idea. Otherwise he would use name callings in `IPv6` addresses as a kind of mnemonics, since
 `GooGoo` was a well-behaved guy, he decided to promote a `DoS` on `IPv6` with his favorite `macgonuts`' command: `maddaddy`.
 
@@ -832,12 +832,12 @@ So all `GooGoo` did was:
 GooGoo@OffTheRoad:~# macgonuts maddaddy --lo-iface=eth0
 ```
 
-At this point `GooGoo` started to listen to `neighbor solicitation` in a certain addressing range and when it found
+At this point `GooGoo` started to listen to `neighbor solicitations` in a certain addressing range and when it found,
 `GooGoo` mocked fake `neighbor advertisements` by avoiding new hosts of ingressing in the network with a valid `IPv6`
 address. As a result no hosts will be automatically configured by `SLAAC`. Muahauhauahuahauhaua!
 
 However, let's supose that `GooGoo` had specific targets. So only those targets should be blocked of ingressing in the network.
-Well all `GooGoo` needed to use was the `--targets` option. This option expects `MAC` addresses separated by comma.
+Well all `GooGoo` needed was the `--targets` option. This option expects `MAC` addresses separated by comma.
 Take a look:
 
 ```
@@ -845,10 +845,10 @@ GooGoo@OffTheRoad:~# macgonuts maddaddy --lo-iface=eth0 \
 > --targets=00:11:22:33:44:55,AA:BB:CC:DD:EE:00,ab:cd:ef:12:23:56
 ```
 
-From now on only the hosts using the indicated `MAC` address would be blocked.
+From now on only the hosts using the indicated `MAC` addresses would be blocked.
 
-So `maddaddy` causes in the target hosts a `"dadfailed"` by making the hosts of automatically be able to have the minimal
-link-local addressing to boot up `IPv6`. You know, `maddaddy` is a kind of bad command for bad people...
+So `maddaddy` causes in the target hosts a `"dadfailed"` by making the hosts of automatically be unable to have a minimal
+link-local addressing to boot up `IPv6`. You know, `maddaddy` is a kind of `bad command for bad people`...
 
 Well, if you did not notice yet, `maddaddy` is a humble tribute to one of my favorite rock bands ever: `The Cramps`!
 

--- a/src/binds/go/sample/main.go
+++ b/src/binds/go/sample/main.go
@@ -17,7 +17,7 @@ import (
 
 func main() {
 	if len(os.Args) < 4 {
-		fmt.Fprintf(os.Stderr, "use: %s <iface> <target-ip> <address-to-spoof> [ <packets-total> <timeout in mss> ]",
+		fmt.Fprintf(os.Stderr, "use: %s <iface> <target-ip> <address-to-spoof> [ <packets-total> <timeout in mss> ]\n",
 			os.Args[0])
 		os.Exit(1)
 	}

--- a/src/binds/go/v1/macgonuts.go
+++ b/src/binds/go/v1/macgonuts.go
@@ -20,10 +20,6 @@ import (
 	"fmt"
 )
 
-// Indicates the current version of the bind stuff. Always it is directly
-// linked to Macgonuts main release version.
-const kMacgonutsGoBindVersion string = "v1"
-
 // The Golang bind for macgonuts_spoof() function from libmacgonuts.
 // By using this function you can easily promote a spoofing attack based on IPv4 or IPv6. It receives:
 // - the local interface label (loIface)
@@ -78,5 +74,5 @@ func UndoSpoof(loIface, targetAddr, addr2Spoof string) error {
 
 // Returns the version of the bind stuff.
 func Version() string {
-	return kMacgonutsGoBindVersion
+	return C.MACGONUTS_VERSION
 }

--- a/src/binds/py/macgonuts.c
+++ b/src/binds/py/macgonuts.c
@@ -9,7 +9,6 @@
 #include <macgonuts_status_info.h>
 #include <binds/macgonuts_binds.h>
 
-
 int macgonuts_pybind_spoof(char *lo_iface, char *target_addr, char *addr2spoof,
                            int fake_pkts_amount, int timeout) {
     if (lo_iface == NULL
@@ -31,4 +30,8 @@ int macgonuts_pybind_undo_spoof(char *lo_iface, char *target_addr, char *addr2sp
     }
 
     return macgonuts_binds_undo_spoof(lo_iface, target_addr, addr2spoof);
+}
+
+void macgonuts_pybind_version(char *version) {
+    snprintf(version, 3, "%s", MACGONUTS_VERSION);
 }

--- a/src/binds/py/macgonuts.h
+++ b/src/binds/py/macgonuts.h
@@ -13,4 +13,6 @@ int macgonuts_pybind_spoof(char *lo_iface, char *target_addr, char *addr2spoof,
 
 int macgonuts_pybind_undo_spoof(char *lo_iface, char *target_addr, char *addr2spoof);
 
+void macgonuts_pybind_version(char *version);
+
 #endif // MACGONUTS_BINDS_PY_MACGONUTS_H

--- a/src/binds/py/macgonuts_pybind.pyx
+++ b/src/binds/py/macgonuts_pybind.pyx
@@ -17,6 +17,9 @@ cdef extern from "macgonuts.h":
 cdef extern from "macgonuts.h":
     int macgonuts_pybind_undo_spoof(char *lo_iface, char *target_addr, char *addr2spoof);
 
+cdef extern from "macgonuts.h":
+    void macgonuts_pybind_version(char *version);
+
 def spoof(lo_iface, target_addr, addr2spoof, fake_pkts_amount = 1, timeout = 0):
     """The python wrapper for macgonuts_spoof() C function
 
@@ -65,4 +68,6 @@ def undo_spoof(lo_iface, target_addr, addr2spoof):
 
 def version():
     """ Returns the version of the bind stuff. """
-    return "v1"
+    cdef char buf[256]
+    macgonuts_pybind_version(buf);
+    return bytes(buf).decode('ascii')

--- a/src/cmd/hooks/macgonuts_dnsspoof_redirect_hook.c
+++ b/src/cmd/hooks/macgonuts_dnsspoof_redirect_hook.c
@@ -34,7 +34,7 @@ int macgonuts_dnsspoof_redirect_hook(struct macgonuts_spoofing_guidance_ctx *spf
     } else {
         spoofed_hostname = macgonuts_get_dns_qname_from_ethernet_frame(ethfrm, ethfrm_size);
         if (spoofed_hostname != NULL
-            && !(macgonuts_gethostbyname(&in_addr[0], spfgd->layers.proto_addr_size, &in_addr_size,
+            && !(macgonuts_gethoaxbyname(&in_addr[0], spfgd->layers.proto_addr_size, &in_addr_size,
                                       macgonuts_dnsspoof_etc_hoax(spfgd),
                                       spoofed_hostname, strlen(spoofed_hostname)) == EXIT_SUCCESS
                  && macgonuts_raw_ip2literal(&lit_addr[0], sizeof(lit_addr) - 1,

--- a/src/macgonuts_dnsspoof.c
+++ b/src/macgonuts_dnsspoof.c
@@ -333,7 +333,7 @@ static int do_dnsspoof_layer4to7(struct macgonuts_udphdr_ctx *udphdr,
 
     err = ENOENT;
     for (qp = dnshdr->qd; qp != NULL && err != EXIT_SUCCESS; qp = qp->next) {
-        err = macgonuts_gethostbyname(in_addr, kWantedInAddrSize[(ip_version == 4)], &in_addr_size, etc_hoax,
+        err = macgonuts_gethoaxbyname(in_addr, kWantedInAddrSize[(ip_version == 4)], &in_addr_size, etc_hoax,
                                       (char *)qp->name, qp->name_size);
     }
 

--- a/src/macgonuts_etc_hoax.c
+++ b/src/macgonuts_etc_hoax.c
@@ -201,7 +201,7 @@ macgonuts_open_etc_hoax_epilogue:
     return etc_hoax_handle;
 }
 
-int macgonuts_gethostbyname(uint8_t *in_addr, const size_t in_addr_max_size, size_t *in_addr_size,
+int macgonuts_gethoaxbyname(uint8_t *in_addr, const size_t in_addr_max_size, size_t *in_addr_size,
                             macgonuts_etc_hoax_handle *etc_hoax, const char *name, const size_t name_size) {
     const macgonuts_etc_hoax_handle *ep = NULL;
     const struct macgonuts_ht_glob_ctx *hp = NULL;

--- a/src/macgonuts_etc_hoax.h
+++ b/src/macgonuts_etc_hoax.h
@@ -16,7 +16,7 @@ macgonuts_etc_hoax_handle *macgonuts_open_etc_hoax(const char *filepath);
 
 void macgonuts_close_etc_hoax(macgonuts_etc_hoax_handle *etc_hoax);
 
-int macgonuts_gethostbyname(uint8_t *in_addr, const size_t in_addr_max_size, size_t *in_addr_size,
+int macgonuts_gethoaxbyname(uint8_t *in_addr, const size_t in_addr_max_size, size_t *in_addr_size,
                             macgonuts_etc_hoax_handle *etc_hoax, const char *name, const size_t name_size);
 
 #endif // MACGONUTS_ETC_HOAX_H

--- a/src/test/macgonuts_etc_hoax_tests.c
+++ b/src/test/macgonuts_etc_hoax_tests.c
@@ -66,22 +66,22 @@ CUTE_TEST_CASE(macgonuts_etc_hoax_tests)
     fclose(fp);
     etc_hoax_handle = macgonuts_open_etc_hoax("etc-hoax");
     CUTE_ASSERT(etc_hoax_handle != NULL);
-    CUTE_ASSERT(macgonuts_gethostbyname(NULL, sizeof(in_addr), &in_addr_size, etc_hoax_handle, "abc", 3) == EINVAL);
-    CUTE_ASSERT(macgonuts_gethostbyname(in_addr, 0, &in_addr_size, etc_hoax_handle, "abc", 3) == EINVAL);
-    CUTE_ASSERT(macgonuts_gethostbyname(in_addr, sizeof(in_addr), NULL, etc_hoax_handle, "abc", 3) == EINVAL);
-    CUTE_ASSERT(macgonuts_gethostbyname(in_addr, sizeof(in_addr), &in_addr_size, NULL, "abc", 3) == EINVAL);
-    CUTE_ASSERT(macgonuts_gethostbyname(in_addr, sizeof(in_addr), &in_addr_size, etc_hoax_handle, NULL, 3) == EINVAL);
-    CUTE_ASSERT(macgonuts_gethostbyname(in_addr, sizeof(in_addr), &in_addr_size, etc_hoax_handle, "abc", 0) == EINVAL);
+    CUTE_ASSERT(macgonuts_gethoaxbyname(NULL, sizeof(in_addr), &in_addr_size, etc_hoax_handle, "abc", 3) == EINVAL);
+    CUTE_ASSERT(macgonuts_gethoaxbyname(in_addr, 0, &in_addr_size, etc_hoax_handle, "abc", 3) == EINVAL);
+    CUTE_ASSERT(macgonuts_gethoaxbyname(in_addr, sizeof(in_addr), NULL, etc_hoax_handle, "abc", 3) == EINVAL);
+    CUTE_ASSERT(macgonuts_gethoaxbyname(in_addr, sizeof(in_addr), &in_addr_size, NULL, "abc", 3) == EINVAL);
+    CUTE_ASSERT(macgonuts_gethoaxbyname(in_addr, sizeof(in_addr), &in_addr_size, etc_hoax_handle, NULL, 3) == EINVAL);
+    CUTE_ASSERT(macgonuts_gethoaxbyname(in_addr, sizeof(in_addr), &in_addr_size, etc_hoax_handle, "abc", 0) == EINVAL);
     while (test != test_end) {
-        CUTE_ASSERT(macgonuts_gethostbyname(in_addr, test->expected_in_addr_size, &in_addr_size,
+        CUTE_ASSERT(macgonuts_gethoaxbyname(in_addr, test->expected_in_addr_size, &in_addr_size,
                                             etc_hoax_handle, test->name, strlen(test->name)) == EXIT_SUCCESS);
         CUTE_ASSERT(in_addr_size == test->expected_in_addr_size);
         CUTE_ASSERT(memcmp(in_addr, test->expected_in_addr, in_addr_size) == 0);
         test++;
     }
-    CUTE_ASSERT(macgonuts_gethostbyname(in_addr, sizeof(in_addr), &in_addr_size,
+    CUTE_ASSERT(macgonuts_gethoaxbyname(in_addr, sizeof(in_addr), &in_addr_size,
                                         etc_hoax_handle, "404", 3) == ENOENT);
-    CUTE_ASSERT(macgonuts_gethostbyname(in_addr, sizeof(in_addr), &in_addr_size,
+    CUTE_ASSERT(macgonuts_gethoaxbyname(in_addr, sizeof(in_addr), &in_addr_size,
                                         etc_hoax_handle, "commented.io", 12) == ENOENT);
     macgonuts_close_etc_hoax(etc_hoax_handle);
     remove("etc-hoax");


### PR DESCRIPTION
Minor change just for avoid wasting this such lousy pun.

Also tying binds version with the libmacgonuts version.